### PR TITLE
Update readme to correct version of Unicode used

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _unicode-property-value-aliases_ offers the Unicode property value alias mappings in an easy-to-consume JavaScript format.
 
-It’s based on [the `PropertyValueAliases.txt` data for Unicode v11.0.0](https://unicode.org/Public/11.0.0/ucd/PropertyValueAliases0d16.txt).
+It’s based on [the `PropertyValueAliases.txt` data for Unicode v13.0.0](https://unicode.org/Public/13.0.0/ucd/PropertyValueAliases.txt).
 
 For the subset used by Unicode RegExp property escapes in ECMAScript, [see _unicode-property-value-aliases-ecmascript_](https://github.com/mathiasbynens/unicode-property-value-aliases-ecmascript).
 


### PR DESCRIPTION
https://github.com/mathiasbynens/unicode-property-value-aliases/commit/ce9554d08868e1244127e2f925641c7a45d36586 and https://github.com/mathiasbynens/unicode-property-value-aliases/commit/a0528a4135365fd10879e657a4890d2969bba857 updated the data, but not the version mentioned in the readme.